### PR TITLE
Cb 286 run m gottschalkii samples through rna seq pipeline on tower

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,9 +14,9 @@ process {
     memory = { check_max( 6.GB * task.attempt, 'memory' ) }
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
-    maxRetries    = 1
-    maxErrors     = '-1'
+    errorStrategy = { task.exitStatus in [143,137,104,134,139,127] ? 'retry' : 'finish' }
+    maxRetries = 5
+    maxErrors = '-1'
 
     // Process-specific resource requirements
     // NOTE - Please try and re-use the labels below as much as possible.
@@ -56,6 +56,10 @@ process {
     withLabel:error_retry {
         errorStrategy = 'retry'
         maxRetries    = 2
+    }
+    withName: 'NFCORE_RNASEQ:RNASEQ:SORTMERNA' {
+         cpus = 16
+         memory = 128.GB
     }
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -31,8 +31,8 @@ if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input sample
 
 // Check rRNA databases for sortmerna
 if (params.remove_ribo_rna) {
-    ch_ribo_db = Channel.fromPath(params.index_dir, checkIfExists: true)
-    ch_smr_fastas = Channel.fromPath(params.silva_reference, checkIfExists: true)
+    ch_ribo_db = Channel.value(file(params.index_dir, checkIfExists: true))
+    ch_smr_fastas = Channel.value(file(params.silva_reference, checkIfExists: true))
 }
 
 // Check if file with list of fastas is provided when running BBSplit


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
- [x] 🔥 Performance Improvements


## Description
Some fixes I needed to make to run the M. gottschalkii samples through the pipeline on the Tower:

1. increased sortmerna's default min memory requirements so that it doesn't choke at the end of the task.
2. made the channel for the pre-made silva db index reusable so that it's not exhausted on the first sample.

## Jira Task

[CB-286.](https://arkeabio.atlassian.net/browse/CB-286)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 notebook(s)
- [x] 🙅 no documentation needed

## Code Quality
- [x] 🎯 The code is properly formatted and adheres to the project's style guide
- [x] 🎯 The code runs without any errors or exceptions

## Compute Environment

The Tower.

## Testing

None needed. See complete run [here](https://tower.nf/orgs/ArkeaBio/workspaces/Computational_Biology/watch/4dmDGlqDiJgHQ7) and the MultiQC report [here](https://arkeabio-nf-30daydelete.s3.amazonaws.com/scratch/4dmDGlqDiJgHQ7/6b/97d84f297bfd48db6b29a86dc20ddb/ArkeaBio-RNA-Seq-Pipeline-for-Methanobrevibacter-gottschalkii-transcriptomics-study_multiqc_report.html?response-content-disposition=inline&response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20231010T134752Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86399&X-Amz-Credential=AKIAUZBB5SZTFS54AS4D%2F20231010%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=22e37ec6b2b2e1b4259b18654465281d7829376e4db4d5d5c2a1eb16e2164c9f).